### PR TITLE
Update pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,24 +8,18 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.0.1
     hooks:
-      - id: trailing-whitespace
-      - id: check-merge-conflict
-      - id: end-of-file-fixer
       - id: check-added-large-files
+      - id: check-ast
       - id: check-byte-order-marker
       - id: check-case-conflict
       - id: check-docstring-first
       - id: check-json
+      - id: check-merge-conflict
       - id: check-symlinks
-      - id: detect-private-key
-      - id: check-ast
-      - id: debug-statements
-
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
-    hooks:
       - id: check-toml
       - id: check-yaml
+      - id: debug-statements
+      - id: detect-private-key
       - id: end-of-file-fixer
       - id: trailing-whitespace
 

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -6,7 +6,7 @@ presubmits:
     context: aicoe-ci/prow/pre-commit
     spec:
       containers:
-        - image: quay.io/thoth-station/thoth-precommit-py38:v0.12.5
+        - image: quay.io/thoth-station/thoth-precommit-py38:v0.13.0
           command:
             - "pre-commit"
             - "run"


### PR DESCRIPTION
# Related Issues and Dependencies

PR #45 is failing pre-commit tests with:

```
[ERROR] The hook `black` requires pre-commit version 2.9.2 but version 2.7.1 is installed.  Perhaps run `pip install --upgrade pre-commit`. 
```

# Description

This PR:
- updates prow config to the current latest tag for the pre-commit image, [v0.13.0](https://quay.io/repository/thoth-station/thoth-precommit/manifest/sha256:4e1e07eb7c6fae544fd29217157495f40f8925ffcb82d9e48b9971f1a92922f8). That version includes `pre-commit 2.12.1`.
- removes redundant configuration entries for pre-commit hooks
